### PR TITLE
add last_reviewer to application

### DIFF
--- a/backend/models/application.js
+++ b/backend/models/application.js
@@ -67,6 +67,10 @@ module.exports = mongoose.model(
         required: true,
         default: false,
       },
+      last_reviewer: {
+        type: String,
+        default: "",
+      },
     },
     {
       timestamps: {

--- a/backend/services/reviews.js
+++ b/backend/services/reviews.js
@@ -49,6 +49,10 @@ async function updateReview(raw_review, submitter) {
   if (review.completed && review.comments === "") {
     throw ServiceError(400, "Comments cannot be empty; please justify your decision");
   }
+
+  // populates last_reviewer field of associated application
+  review.application.last_reviewer = submitter.name;
+
   await review.save();
   if (review.completed) {
     try {

--- a/frontend/src/pages/recruitment/Applications.js
+++ b/frontend/src/pages/recruitment/Applications.js
@@ -133,6 +133,7 @@ const Applications = () => {
                   },
                   { title: "Completed", field: "completed", type: "boolean" },
                   { title: "Accepted", field: "accepted", type: "boolean" },
+                  { title: "Last Reviewer", field: "last_reviewer" },
                 ]}
                 data={state.applications}
                 title="All Applications"


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Added last_reviewer field to applications model
- Changed /recruitment/applications table to include a column for last reviewer

### Testing
How did you confirm your changes worked? 
- Create a new application and had example pm review it 

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

A freshly submitted application has no last_reviewer
![image](https://user-images.githubusercontent.com/55808666/114253487-41cf9c80-995f-11eb-93ce-0703794a9353.png)

After some interviews, application is updated to reflect who interviewed them last
![image](https://user-images.githubusercontent.com/55808666/114253516-64fa4c00-995f-11eb-9344-d5f98c9417dc.png)

Frontend rendition
![image](https://user-images.githubusercontent.com/55808666/114253534-73e0fe80-995f-11eb-9ee2-685de6db3678.png)





