### PR TITLE
Improve pre-commit hook behavior during merge

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -82,7 +82,13 @@ lint_check() {
 }
 
 main() {
-	stash_push && trap stash_pop EXIT
+	if [ -f '.git/MERGE_HEAD' ]; then
+		log "WARNING: unable to stash unstaged changes during merge." \
+			"If there are unstaged changes, they may result in an" \
+			"incorrect lint check result."
+	else
+		stash_push && trap stash_pop EXIT
+	fi
 
 	lint_check
 }


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Fix unexpected behavior when using pre-commit hook during merge (attempting to stash changes resulted in a fatal error "could not open MERGE_HEAD").

### Testing
How did you confirm your changes worked? 
- Created two branches with conflicting changes, merged one into the other, fixed the merge conflict, and verified that the pre-commit hook ran successfully

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

![image](https://user-images.githubusercontent.com/19500553/116308504-69df3e00-a75c-11eb-92b5-c3244ee8118e.png)
