### PR TITLE
Fix incorrect import for material-ui Autocomplete

### DIFF
--- a/frontend/src/pages/recruitment/pipeline/PipelineCard.js
+++ b/frontend/src/pages/recruitment/pipeline/PipelineCard.js
@@ -13,7 +13,7 @@ import {
   TextField,
 } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
-import { Autocomplete } from "@material-ui/lab/Autocomplete";
+import { Autocomplete } from "@material-ui/lab";
 import { useDispatch } from "react-redux";
 
 import { withAuthorization } from "../../../components/HOC";


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Revert a change I made to the import path for Autocomplete, which broke the Heroku build

### Testing
How did you confirm your changes worked? 
- Started the frontend and backend and confirmed that the pipeline page works now

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

![image](https://user-images.githubusercontent.com/19500553/116479538-a9795900-a834-11eb-9be0-29cc2745551a.png)
