### PR TITLE
Check for undefined/null before comparing fields

### DIFF
--- a/backend/services/users.js
+++ b/backend/services/users.js
@@ -94,7 +94,13 @@ async function editUser(rawUser, editingUser) {
     throw ServiceError(404, "User does not exist");
   }
   for (const [field, newValue] of Object.entries(rawUser)) {
-    if (field === "_id" || newValue.toString() === editedUser[field].toString()) continue;
+    if (
+      field === "_id" ||
+      // eslint-disable-next-line eqeqeq
+      (editedUser[field] != undefined && newValue.toString() === editedUser[field].toString())
+    ) {
+      continue;
+    }
     if (editableFields.has(field)) {
       editedUser[field] = newValue;
     } else {


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Check for null/undefined before comparing field values in the edit user route. This fixes an issue where, if an attribute is not set, the backend crashes because it attempts to call `.toString()` on `undefined`. (This affects the production deployment, where the existing user accounts are missing these optional attributes.)

### Testing
How did you confirm your changes worked? 
- Removed the LinkedIn username from the developer account in the mock data, and confirmed that I was able to set a LinkedIn account on the frontend without an error

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

- See above for instructions