### PR TITLE
Make graduation fields editable on Settings page

### DIFF
--- a/backend/services/users.js
+++ b/backend/services/users.js
@@ -8,11 +8,13 @@ const { sendEmail } = require("./email");
 // User model fields that are editable by normal users (editing themselves) and admins (editing anyone)
 const USER_EDITABLE = new Set([
   "phone",
+  "grad_quarter",
+  "graduation",
   "discord_username",
   "github_username",
   "linkedin_username",
 ]);
-const ADMIN_EDITABLE = new Set([...USER_EDITABLE, "email", "name", "graduation", "role", "active"]);
+const ADMIN_EDITABLE = new Set([...USER_EDITABLE, "email", "name", "role", "active"]);
 
 async function createUser(raw_user) {
   let user = await User.findOne({ email: raw_user.email }).exec();

--- a/frontend/src/components/UserEdit.js
+++ b/frontend/src/components/UserEdit.js
@@ -70,6 +70,16 @@ const UserEdit = ({ userData }) => {
     },
   });
 
+  const handleUserChange = (prop) => (event) => {
+    setState({
+      ...state,
+      user: {
+        ...state.user,
+        [prop]: event.target.value,
+      },
+    });
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     const { ok, data } = await editUser(state.user);
@@ -118,15 +128,7 @@ const UserEdit = ({ userData }) => {
                 variant="outlined"
                 type="text"
                 defaultValue={userData.user.name}
-                onChange={(event) => {
-                  setState({
-                    ...state,
-                    user: {
-                      ...state.user,
-                      name: event.target.value,
-                    },
-                  });
-                }}
+                onChange={handleUserChange("name")}
               />
               <TextField
                 select
@@ -145,15 +147,7 @@ const UserEdit = ({ userData }) => {
                     getContentAnchorEl: null,
                   },
                 }}
-                onChange={(event) => {
-                  setState({
-                    ...state,
-                    user: {
-                      ...state.user,
-                      role: event.target.value,
-                    },
-                  });
-                }}
+                onChange={handleUserChange("role")}
               >
                 {state.roles.map((role) => (
                   <MenuItem key={role._id} value={role._id}>
@@ -166,15 +160,7 @@ const UserEdit = ({ userData }) => {
                 variant="outlined"
                 type="email"
                 defaultValue={userData.user.email}
-                onChange={(event) => {
-                  setState({
-                    ...state,
-                    user: {
-                      ...state.user,
-                      email: event.target.value,
-                    },
-                  });
-                }}
+                onChange={handleUserChange("email")}
               />
             </>
           ) : (
@@ -206,15 +192,7 @@ const UserEdit = ({ userData }) => {
             variant="outlined"
             value={state.user.grad_quarter}
             align="left"
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  grad_quarter: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("grad_quarter")}
             SelectProps={{
               MenuProps: {
                 anchorOrigin: {
@@ -234,77 +212,37 @@ const UserEdit = ({ userData }) => {
           <TextField
             label="Graduation Year"
             variant="outlined"
-            type="text"
+            type="number"
             defaultValue={userData.user.graduation}
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  graduation: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("graduation")}
           />
           <TextField
             label="Phone Number"
             variant="outlined"
             type="text"
             defaultValue={userData.user.phone}
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  phone: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("phone")}
           />
           <TextField
             label="Github User"
             variant="outlined"
             type="text"
             defaultValue={userData.user.github_username}
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  github_username: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("github_username")}
           />
           <TextField
             label="Discord User"
             variant="outlined"
             type="text"
             defaultValue={userData.user.discord_username}
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  discord_username: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("discord_username")}
           />
           <TextField
             label="LinkedIn User"
             variant="outlined"
             type="text"
             defaultValue={userData.user.linkedin_username}
-            onChange={(event) => {
-              setState({
-                ...state,
-                user: {
-                  ...state.user,
-                  linkedin_username: event.target.value,
-                },
-              });
-            }}
+            onChange={handleUserChange("linkedin_username")}
           />
           <Button
             disableElevation

--- a/frontend/src/components/UserEdit.js
+++ b/frontend/src/components/UserEdit.js
@@ -8,7 +8,6 @@ import {
   Typography,
   Button,
   TextField,
-  Select,
   MenuItem,
   Divider,
 } from "@material-ui/core";
@@ -51,6 +50,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const UserEdit = ({ userData }) => {
+  const quarters = ["Fall", "Winter", "Spring", "Summer"];
   const classes = useStyles();
   const dispatch = useDispatch();
   const [state, setState] = useState({
@@ -61,6 +61,7 @@ const UserEdit = ({ userData }) => {
       _id: userData.user._id,
       name: userData.user.name,
       role: userData.user.role._id,
+      grad_quarter: userData.user.grad_quarter,
       graduation: userData.user.graduation,
       phone: userData.user.phone,
       github_username: userData.user.github_username,
@@ -127,18 +128,22 @@ const UserEdit = ({ userData }) => {
                   });
                 }}
               />
-              <Select
+              <TextField
+                select
+                label="Role"
                 variant="outlined"
                 defaultValue={userData.user.role._id}
                 renderValue={(value) => state.roleIdToNameMap[value]}
                 className={classes.select}
                 align="left"
-                MenuProps={{
-                  anchorOrigin: {
-                    vertical: "bottom",
-                    horizontal: "left",
+                SelectProps={{
+                  MenuProps: {
+                    anchorOrigin: {
+                      vertical: "bottom",
+                      horizontal: "left",
+                    },
+                    getContentAnchorEl: null,
                   },
-                  getContentAnchorEl: null,
                 }}
                 onChange={(event) => {
                   setState({
@@ -155,22 +160,7 @@ const UserEdit = ({ userData }) => {
                     {role.name}
                   </MenuItem>
                 ))}
-              </Select>
-              <TextField
-                label="Year"
-                variant="outlined"
-                type="text"
-                defaultValue={userData.user.graduation}
-                onChange={(event) => {
-                  setState({
-                    ...state,
-                    user: {
-                      ...state.user,
-                      graduation: event.target.value,
-                    },
-                  });
-                }}
-              />
+              </TextField>
               <TextField
                 label="Email"
                 variant="outlined"
@@ -204,16 +194,58 @@ const UserEdit = ({ userData }) => {
                 {state.roleIdToNameMap[userData.user.role._id]}
               </Typography>
               <Typography className={classes.nonEdit} variant="caption">
-                Graduation Year
-              </Typography>
-              <Typography className={classes.nonEdit}>{userData.user.graduation}</Typography>
-              <Typography className={classes.nonEdit} variant="caption">
                 Email
               </Typography>
               <Typography className={classes.nonEdit}>{userData.user.email}</Typography>
               <Divider />
             </div>
           )}
+          <TextField
+            select
+            label="Graduation Quarter"
+            variant="outlined"
+            value={state.user.grad_quarter}
+            align="left"
+            onChange={(event) => {
+              setState({
+                ...state,
+                user: {
+                  ...state.user,
+                  grad_quarter: event.target.value,
+                },
+              });
+            }}
+            SelectProps={{
+              MenuProps: {
+                anchorOrigin: {
+                  vertical: "bottom",
+                  horizontal: "left",
+                },
+                getContentAnchorEl: null,
+              },
+            }}
+          >
+            {quarters.map((qtr) => (
+              <MenuItem key={qtr} value={qtr}>
+                {qtr}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Graduation Year"
+            variant="outlined"
+            type="text"
+            defaultValue={userData.user.graduation}
+            onChange={(event) => {
+              setState({
+                ...state,
+                user: {
+                  ...state.user,
+                  graduation: event.target.value,
+                },
+              });
+            }}
+          />
           <TextField
             label="Phone Number"
             variant="outlined"


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Added graduation quarter to Settings form
- Made graduation year editable for everyone

### Testing
How did you confirm your changes worked? 
- Updated grad info in PM account (no admin/user edit permissions) and checked database change

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

| No Edit Permissions View |
| --- |
| ![1](https://user-images.githubusercontent.com/64985802/119280526-b47e9980-bbe6-11eb-81b4-44d516d6549e.JPG) |

| Updating Graduation Info |
| --- |
| ![2](https://user-images.githubusercontent.com/64985802/119280646-2d7df100-bbe7-11eb-8d6c-934eb2ddb39b.JPG) |

| Updated User in Database |
| --- |
| ![3](https://user-images.githubusercontent.com/64985802/119280668-3cfd3a00-bbe7-11eb-86d8-eee9dfbc10f3.JPG) |
