### PR TITLE
Read deployment URL from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ There are several environment variables that must be set for the backend to work
 - (optional, defaults to 'keyboard cat') JWT_SECRET = used to uniquely identifying tokens, must be changed in production
 - (optional, defaults to '') EMAIL_USERNAME = used for automated emailing, disabled if left empty
 - (optional, defaults to '') EMAIL_PASSWORD = used for automated emailing, disabled if left empty
+- (optional, defaults to 'http://localhost:3000') DEPLOYMENT_URL = URL to the Oktavian deployment, used to send links in emails
 
 The recommended way to specify this environment variables is by creating the
 file `backend/.env` and listing the variables there. The `.env` file is not

--- a/backend/constants/index.js
+++ b/backend/constants/index.js
@@ -8,5 +8,6 @@ module.exports = {
   MONGO_URI: process.env.MONGO_URI || "mongodb://127.0.0.1:27017/tse-oktavian",
   EMAIL_USERNAME: process.env.EMAIL_USERNAME || "",
   EMAIL_PASSWORD: process.env.EMAIL_PASSWORD || "",
+  DEPLOYMENT_URL: process.env.DEPLOYMENT_URL || "http://localhost:3000",
   STAGES: ["Resume", "Phone", "Interview", "Final"],
 };

--- a/backend/emails/password-reset/html.pug
+++ b/backend/emails/password-reset/html.pug
@@ -1,4 +1,4 @@
 p Hello,
 p Use the following link to reset your password:
-p https://tse-oktavian.herokuapp.com/reset-password/#{token}
+p #{DEPLOYMENT_URL}/reset-password/#{token}
 p This link will expire in 1 hour. Please ignore this email if you did not request a password change.

--- a/backend/emails/reviewer-assignment/html.pug
+++ b/backend/emails/reviewer-assignment/html.pug
@@ -1,3 +1,3 @@
 p Hello #{reviewer},
 p You have been assigned to review #{applicant}’s #{role.name} application for the #{current_stage} stage. Please complete this in a timely manner. Have a nice day!
-p A list of application assignments awaiting your review can be found at https://tse-recruitment-portal.herokuapp.com/assignments.
+p A list of application assignments awaiting your review can be found at #{DEPLOYMENT_URL}}/assignments.

--- a/backend/services/email.js
+++ b/backend/services/email.js
@@ -1,53 +1,37 @@
 const nodemailer = require("nodemailer");
 const Email = require("email-templates");
-const { EMAIL_USERNAME, EMAIL_PASSWORD } = require("../constants");
+const { EMAIL_USERNAME, EMAIL_PASSWORD, DEPLOYMENT_URL } = require("../constants");
 
-const transporter =
-  EMAIL_USERNAME === ""
-    ? null
-    : nodemailer.createTransport({
-        host: "smtp.gmail.com",
-        port: 465,
-        secure: true,
-        auth: {
-          user: EMAIL_USERNAME,
-          pass: EMAIL_PASSWORD,
-        },
-      });
-const mail =
-  EMAIL_USERNAME === ""
-    ? null
-    : new Email({
-        transport: transporter,
-        send: true,
-        preview: false,
-      });
-if (mail == null) {
-  console.log("No mail credentials were provided, so automated mail has been disabled.");
-}
+const transporter = nodemailer.createTransport({
+  host: "smtp.gmail.com",
+  port: 465,
+  secure: true,
+  auth: {
+    user: EMAIL_USERNAME,
+    pass: EMAIL_PASSWORD,
+  },
+});
+
+const mail = new Email({ transport: transporter });
 
 /**
  * Responsible for populating an email template and sending to a target email.
- * This function will be a NOP if no mail credentials are provided at the start of the application.
+ * In development, the email will be previewed in the browser instead.
  *
  * @param template a string referring to one of four templates in the email folder
  * @param target_email the recipient's email
  * @param params the template's parameters
  */
 async function sendEmail(template, target_email, params) {
-  if (mail != null) {
-    await mail.send({
-      template,
-      message: {
-        from: EMAIL_USERNAME,
-        to: target_email,
-      },
-      locals: params,
-    });
-    console.log(`Email ${template} has been sent to ${target_email}.`);
-  } else {
-    console.log(`Email ${template} would have been sent to ${target_email} but is disabled.`);
-  }
+  await mail.send({
+    template,
+    message: {
+      from: EMAIL_USERNAME,
+      to: target_email,
+    },
+    locals: { DEPLOYMENT_URL, ...params },
+  });
+  console.log(`Email ${template} has been sent to ${target_email}.`);
 }
 
 module.exports = { sendEmail };


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 1181559666
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Read the deployment URL from an environment variable instead of using a hardcoded value, defaulting to `http://localhost:3000` if not specified
- Modified email templates to reflect this change
- Enabled in-browser email previews in development

### Testing
How did you confirm your changes worked? 
- Reset the example PM's password and got an email preview with a `localhost:3000` URL
- Added `DEPLOYMENT_URL=https://www.example.com` to `backend/.env`, repeated the process, and got an email preview with an `example.com` URL instead

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

| In-browser email preview, which contains a link using the deployment URL from the environment variable |
| --- |
| ![screenshot-20210528-165856](https://user-images.githubusercontent.com/19500553/120051599-1b7cc380-bfd6-11eb-81a8-9d9d86710bca.png) |
